### PR TITLE
Add output_dir functionality

### DIFF
--- a/R/classifyTumor.R
+++ b/R/classifyTumor.R
@@ -164,7 +164,7 @@ classifyCluster <- function(hcc2, norm_cell_names){
 #' @examples
 #' 
 #' @export
-classifyTumorCells <- function(count_mtx, annot_mtx, sample = "", distance="euclidean", par_cores=20, ground_truth = NULL, norm_cell_names = NULL, SEGMENTATION_CLASS = TRUE, SMOOTH = TRUE, beta_vega = 0.5, FIXED_NORMAL_CELLS = FALSE){
+classifyTumorCells <- function(count_mtx, annot_mtx, sample = "", distance="euclidean", par_cores=20, ground_truth = NULL, norm_cell_names = NULL, SEGMENTATION_CLASS = TRUE, SMOOTH = TRUE, beta_vega = 0.5, FIXED_NORMAL_CELLS = FALSE, output_dir = "./output"){
   
   set.seed(1)
   
@@ -235,9 +235,9 @@ classifyTumorCells <- function(count_mtx, annot_mtx, sample = "", distance="eucl
     mtx_vega <- cbind(annot_mtx[,c(4,1,3)], count_mtx_relat)
     colnames(mtx_vega)[1:3] <- c("Name","Chr","Position")
     
-    breaks <- getBreaksVegaMC(mtx_vega, annot_mtx[, 3], sample, beta_vega)
+    breaks <- getBreaksVegaMC(mtx_vega, annot_mtx[, 3], sample, beta_vega, output_dir = output_dir)
     
-    subSegm <- read.csv(paste0("./output/ ",sample," vega_output"), sep = "\t")
+    subSegm <- read.csv(file.path(output_dir, paste0(sample, "vega_output")), sep = "\t")
     
     segmAlt <- abs(subSegm$Mean)>0.05 | (subSegm$G.pv<0.01 | subSegm$L.pv<0.01)
     #segmAlt <- append(segmAlt[1],append(segmAlt, segmAlt[length(segmAlt)]))
@@ -267,8 +267,9 @@ classifyTumorCells <- function(count_mtx, annot_mtx, sample = "", distance="eucl
     #plot heatmap
     print("11) plot heatmap")
     
-    plotCNA(annot_mtx$seqnames, CNA_mtx, hcc, sample)
-    save(CNA_mtx, file = paste0("./output/",sample,"_CNAmtx.RData"))
+    plotCNA(chr_lab = annot_mtx$seqnames, mtx_CNA = CNA_mtx, hcc = hcc, samp = sample, output_dir = output_dir)
+    
+    save(CNA_mtx, file = file.path(output_dir, paste0(sample, "_CNAmtx.RData")))
     
   } else {
     
@@ -320,9 +321,9 @@ classifyTumorCells <- function(count_mtx, annot_mtx, sample = "", distance="eucl
     
     print("11) plot heatmap")
     
-    plotCNA(annot_mtx$seqnames, CNA_mtx_relat, hcc, sample, cellType_pred, ground_truth)
+    plotCNA(annot_mtx$seqnames, CNA_mtx_relat, hcc, sample, cellType_pred, ground_truth, output_dir)
     
-    save(CNA_mtx_relat, file = paste0("./output/",sample,"_CNAmtx.RData"))
+    save(CNA_mtx_relat, file = file.path(output_dir, paste0(sample, "_CNAmtx.RData")))
     
   }
   if(length(norm_cell_names) < 1){

--- a/R/confidentNormal.R
+++ b/R/confidentNormal.R
@@ -58,7 +58,7 @@ top30classification <- function(NES, pValue, FDR, pval_filter, fdr_filter, pval_
 #' @examples
 #' 
 #' @export
-getConfidentNormalCells <- function(mtx, sample = "", par_cores = 20, AdditionalGeneSets = NULL, SCEVANsignatures = TRUE, organism = "human"){
+getConfidentNormalCells <- function(mtx, sample = "", par_cores = 20, AdditionalGeneSets = NULL, SCEVANsignatures = TRUE, organism = "human", output_dir = "./output"){
   
   
   if(organism == "human"){
@@ -73,12 +73,11 @@ getConfidentNormalCells <- function(mtx, sample = "", par_cores = 20, Additional
     geneSet <- AdditionalGeneSets
   }
   
-  system.time(ssMwwGst(geData = mtx, geneSet = geneSet , ncore = par_cores, minLenGeneSet = 5, filename = paste0("./output/",sample,"_confidentNormal"), standardize = TRUE))
-  load(paste0("./output/",sample,"_confidentNormal_MWW.RData"))
+  system.time(ssMwwGst(geData = mtx, geneSet = geneSet , ncore = par_cores, minLenGeneSet = 5, filename = file.path(output_dir, paste0(sample, "_confidentNormal")), standardize = TRUE))
+  load(file.path(output_dir, paste0(sample, "_confidentNormal_MWW.RData")))
   norm.cell.names <- top30classification(NES = NES, FDR = FDR, pValue = pValue, fdr_filter = TRUE, pval_filter = TRUE, pval_cutoff = 1*10^(-10), nes_cutoff = 1.0, nNES = 1)
-  file.remove(paste0("./output/",sample,"_confidentNormal_MWW.RData"))
+  file.remove(file.path(output_dir, paste0(sample, "_confidentNormal_MWW.RData")))
   print(paste("found", length(norm.cell.names), "confident non malignant cells", sep=" "))
   
   return(norm.cell.names)
-  
 }

--- a/R/multiSampleComparisonClonalCN.R
+++ b/R/multiSampleComparisonClonalCN.R
@@ -76,10 +76,11 @@ plotAllClonalCN <- function(samples, name){
 #'
 #' @examples 
 #' 
-multiSampleComparisonClonalCN <- function(listCountMtx, listNormCells = NULL, analysisName = "all", organism = "human" , par_cores = 20, plotTree = TRUE){
-
+multiSampleComparisonClonalCN <- function(listCountMtx, listNormCells = NULL, analysisName = "all", organism = "human" , par_cores = 20, plotTree = TRUE, output_dir = "./output"){
+  #TODO add the output_dir var here as well, apply it to the plotting func
+  
   resList <- lapply(names(listCountMtx), function(x) {
-    pipelineCNA(listCountMtx[[x]], norm_cell = listNormCells[[x]], sample = x, SUBCLONES = FALSE, ClonalCN = TRUE, par_cores = par_cores, organism=organism)
+    pipelineCNA(listCountMtx[[x]], norm_cell = listNormCells[[x]], sample = x, SUBCLONES = FALSE, ClonalCN = TRUE, par_cores = par_cores, organism = organism, output_dir = outpur_dir)
   })
   names(resList) <- names(listCountMtx)
   
@@ -110,7 +111,7 @@ multiSampleComparisonClonalCN <- function(listCountMtx, listNormCells = NULL, an
   
   plotAllClonalCN(names(listCountMtx), name = analysisName)
   
-  if(length(names(listCountMtx))>2 & plotTree) plotCloneTreeNew(names(listCountMtx), CLONAL_MULTI = TRUE, analysisName = analysisName)
+  if(length(names(listCountMtx))>2 & plotTree) plotCloneTreeNew(names(listCountMtx), CLONAL_MULTI = TRUE, analysisName = analysisName, output_dir = output_dir)
   
   for(i in 1:length(names(listCountMtx))){
     names(diffList) <- gsub(paste0("subclone",i), names(listCountMtx)[i], names(diffList))
@@ -120,7 +121,8 @@ multiSampleComparisonClonalCN <- function(listCountMtx, listNormCells = NULL, an
 
   outputAnalysis <- list(resList, diffList)
   
-  save(outputAnalysis, file = paste0("./output/",analysisName,"_outputAnalysis.RData"))
+  
+  save(outputAnalysis, file = file.path(output_dir, paste0(analysisName, "_outputAnalysis.RData")))
   
   outputAnalysis
   

--- a/R/mwwFunc.R
+++ b/R/mwwFunc.R
@@ -62,7 +62,9 @@ ssMwwGst <- function(geData, geneSet, ncore,  minLenGeneSet = 15 , regulon = FAL
   pValue <- sapply(ans, function(x) x$tmp_pValue)
   colnames(NES) <- colnames(pValue) <- colnames(geData)
   FDR <- apply(pValue, 2, function(x) p.adjust(x, method = "fdr"))
+  
   save(NES, pValue, FDR, file = paste0(filename, "_MWW.RData"))
+  #TODO left off here, some mistake happening in loading the MWW.RData file.
 }
 
 

--- a/R/plotSegmentation.R
+++ b/R/plotSegmentation.R
@@ -1,6 +1,7 @@
 
 
 getCorrelationCN <- function(CNVref, CNVcomp){
+  #TODO - add the standard output dir as var for the function
   
   df_1 <- as.data.frame(approx(CNVcomp$Pos,CNVcomp$Mean, seq(min(CNVref$Pos,CNVcomp$Pos),max(CNVref$Pos,CNVcomp$Pos), by = 1), ties = "ordered"))
   df_2 <- as.data.frame(approx(CNVref$Pos,CNVref$Mean, seq(min(CNVref$Pos,CNVcomp$Pos), max(CNVref$Pos,CNVcomp$Pos), by = 1), ties = "ordered"))
@@ -153,18 +154,22 @@ plotSegmentation <- function(CNV, organism = "human", modifyPosSeg = TRUE, CN = 
   abline(v=extr_chr, col="black", lwd = 2)
 }
 
-getScevanCNVfinal <- function(sample , path = "", subclone = NULL){
+getScevanCNVfinal <- function(sample , path = "./output", subclone = NULL){
   if(is.null(subclone)){
-    CNV_infer <- read.table(paste0(path,"./output/",sample, "_Clonal_CN.seg"), sep="\t", header=TRUE, as.is=TRUE)
+
+    CNV_infer <- read.table(file.path(path, paste0(sample, "_Clonal_CN.seg")), sep="\t", header=TRUE, as.is=TRUE)
   }else{
-    CNV_infer <- read.table(paste0(path,"./output/",sample,"_subclone",subclone,"_CN.seg"), sep="\t", header=TRUE, as.is=TRUE)
+    CNV_infer <- read.table(file.path(path, paste0(sample, "_subclone", subclone, "_CN.seg")), sep="\t", header=TRUE, as.is=TRUE)
   }
   CNV_infer
 }
 
 
-getScevanCNV <- function(sample , path = "" , filter = FALSE, beta = ""){
-  CNV_infer <- read.table(paste0(path,"./output/ ",sample, beta," vega_output"), sep="\t", header=TRUE, as.is=TRUE)
+getScevanCNV <- function(sample , path = "./output" , filter = FALSE, beta = ""){
+  #TODO the read.table functions also refer to the ./output folder, meaning that 
+  # those need to be changed around as well
+  
+  CNV_infer <- read.table(file.path(path, paste0(sample, beta, "vega_output")), sep="\t", header=TRUE, as.is=TRUE)
   
   if(filter) CNV_infer[!((CNV_infer$Mean<(-0.10) | CNV_infer$L.pv<0.01) | (CNV_infer$Mean>0.10 | CNV_infer$G.pv<0.01)),]$Mean <- 0 
   
@@ -231,35 +236,37 @@ heatmapConsensusPlot <- function(CNV,sample,file, CN = TRUE){
     
 }
 
-plotCNclonal_old <- function(sample,ClonalCN, organism = "human"){
-  
-  if(ClonalCN) {
-    fileNames <- c("ClonalCNProfile","onlytumor")
-  }else{
-    fileNames <- c("onlytumor")
-  }
-  
-  for(name in fileNames){
-    
-    if(name == "ClonalCNProfile"){
-      file = "_coarse-grained"
-    }else{
-      file = "_fine-grain_"
-    }
-    
-    segm <- getScevanCNV(paste0(sample,name))
-    png(paste("./output/",sample,file,"ClonalCNProfile.png",sep=""), height=1050, width=2250, res=250) 
-    plotSegmentation(CNV = segm, organism = organism)
-    dev.off()
-    png(paste("./output/",sample,file,"consensus.png",sep=""), height=650, width=3150, res=180)
-    heatmapConsensusPlot(segm,sample,file)
-    dev.off()
-    }
-}
+# plotCNclonal_old <- function(sample,ClonalCN, organism = "human"){
+#   
+#   if(ClonalCN) {
+#     fileNames <- c("ClonalCNProfile","onlytumor")
+#   }else{
+#     fileNames <- c("onlytumor")
+#   }
+#   
+#   for(name in fileNames){
+#     
+#     if(name == "ClonalCNProfile"){
+#       file = "_coarse-grained"
+#     }else{
+#       file = "_fine-grain_"
+#     }
+#     
+#     #TODO
+#     # change from ./output to output_dir
+#     segm <- getScevanCNV(paste0(sample,name))
+#     png(paste("./output/",sample,file,"ClonalCNProfile.png",sep=""), height=1050, width=2250, res=250) 
+#     plotSegmentation(CNV = segm, organism = organism)
+#     dev.off()
+#     png(paste("./output/",sample,file,"consensus.png",sep=""), height=650, width=3150, res=180)
+#     heatmapConsensusPlot(segm,sample,file)
+#     dev.off()
+#     }
+# }
   
 
 
-plotCNclonal <- function(sample, ClonalCN, organism = "human"){
+plotCNclonal <- function(sample, ClonalCN, organism = "human", output_dir = "./output"){
   
   if(ClonalCN) {
     fileNames <- c("ClonalCNProfile","onlytumor")
@@ -280,10 +287,13 @@ plotCNclonal <- function(sample, ClonalCN, organism = "human"){
     }else{
       segm <- getScevanCNV(paste0(sample,name))
     }
-    png(paste("./output/",sample,file,"ClonalCNProfile.png",sep=""), height=1050, width=2250, res=250) 
+    
+    
+    png(file.path(output_dir, paste0(sample, file, "ClonalCNProfile.png")), height=1050, width=2250, res=250) 
     plotSegmentation(CNV = segm, organism = organism)
     dev.off()
-    png(paste("./output/",sample,file,"consensus.png",sep=""), height=650, width=3150, res=180)
+    
+    png(file.path(output_dir, paste0(sample, file, "consensus.png")), height=650, width=3150, res=180)
     heatmapConsensusPlot(segm,sample,file)
     dev.off()
   }

--- a/R/preProcessing.R
+++ b/R/preProcessing.R
@@ -71,7 +71,7 @@ annotateGenes <- function(mtx, organism = "human"){
 #' @examples
 #' count_mtx_annot <- annotateGenes(count_mtx)
 #' @export
-preprocessingMtx <- function(count_mtx, sample, ngenes_chr=5, perc_genes=0.1, par_cores=20, findConfident = TRUE, AdditionalGeneSets = NULL, SCEVANsignatures = TRUE, organism = "human"){
+preprocessingMtx <- function(count_mtx, sample, ngenes_chr=5, perc_genes=0.1, par_cores=20, findConfident = TRUE, AdditionalGeneSets = NULL, SCEVANsignatures = TRUE, organism = "human", output_dir = "./output"){
   
   set.seed(123)
   
@@ -111,7 +111,7 @@ preprocessingMtx <- function(count_mtx, sample, ngenes_chr=5, perc_genes=0.1, pa
   rownames(count_mtx) <- count_mtx_annot$gene_name
   
   if(findConfident){
-    norm_cell <- getConfidentNormalCells(count_mtx, sample, par_cores = par_cores, AdditionalGeneSets = AdditionalGeneSets, SCEVANsignatures = SCEVANsignatures, organism = organism)
+    norm_cell <- getConfidentNormalCells(count_mtx, sample, par_cores = par_cores, AdditionalGeneSets = AdditionalGeneSets, SCEVANsignatures = SCEVANsignatures, organism = organism, output_dir = output_dir)
   }else{
     norm_cell <- NULL
   }

--- a/R/testFunc.R
+++ b/R/testFunc.R
@@ -49,7 +49,7 @@ calinsky <- function (hhc, dist = NULL, gMax = round(1 + 3.3 * log(length(hhc$or
   return(ans)
 }
 
-subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res_proc, hc.clus = NULL, relativeSmoothMtx = NULL, organism = "human"){
+subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res_proc, hc.clus = NULL, relativeSmoothMtx = NULL, organism = "human", output_dir = "./output"){
   
   library(scran)
   
@@ -114,7 +114,7 @@ subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res
     perc_cells_subclones <- table(hc.clus)/length(hc.clus)
     
     print(paste("found", n_subclones, "subclones", sep = " "))
-    names(perc_cells_subclones) <- paste0("percentage_cells_subsclone_",names(perc_cells_subclones))
+    names(perc_cells_subclones) <- paste0("percentage_cells_subclone_",names(perc_cells_subclones))
     print(perc_cells_subclones)
     
     breaks_subclones <- list()
@@ -139,7 +139,7 @@ subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res
       
       i <- i - length(falseSub)
       
-      breaks_subclones[[i]] <- getBreaksVegaMC(mtx_vega, CNAmat[,3], paste0(samp,"_subclone",i), beta_vega = 0.5)
+      breaks_subclones[[i]] <- getBreaksVegaMC(mtx_vega, CNAmat[,3], paste0(samp,"_subclone",i), beta_vega = 0.5, output_dir = output_dir)
       
       #mtx_CNA3 <- computeCNAmtx(norm.mat.relat[,tum_cells_sub1], breaks_subclones[[i]], n.cores, rep(TRUE, length(breaks_subclones[[i]])))
       
@@ -151,10 +151,11 @@ subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res
       CNV[[i]] <- getCNcall(norm.mat.relat[,tum_cells_sub1], res_proc$count_mtx_annot, breaks_subclones[[i]], sample = samp, subclone = i, par_cores = n.cores, organism = organism)
       
       if(any(CNV[[i]]$CN!=2)){
-        segm.mean <- getScevanCNV(paste0(samp,"_subclone",i))$Mean
+        segm.mean <- getScevanCNV(paste0(samp,"_subclone",i), path = output_dir)$Mean
         CNV[[i]] <- cbind(CNV[[i]],segm.mean)
-        write.table(CNV[[i]], file = paste0("./output/",samp,"_subclone",i,"_CN.seg"), sep = "\t", quote = FALSE)
-        file.remove(paste0("./output/ ",paste0(samp,"_subclone",i)," vega_output"))
+        
+        write.table(CNV[[i]], file = file.path(output_dir, paste0(samp, "_subclone", i, "_CN.seg")), sep = "\t", quote = FALSE)
+        file.remove(file.path(output_dir, paste0(samp, "_subclone", i, "vega_output")))
         
         mtx_CNA3 <- computeCNAmtx(norm.mat.relat[,tum_cells_sub1], breaks_subclones[[i]], n.cores, CNV[[i]]$CN != 2)
         
@@ -190,8 +191,10 @@ subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res
     
     hcc <- hclust(parallelDist::parDist(t(results.com),threads = 20, method = "euclidean"), method = "ward.D")
     
-    plotSubclones(CNAmat[,2], results.com,hcc, n_subclones, samp)
-    save(results.com, file = paste0("./output/",samp,"_CNAmtxSubclones.RData"))
+    plotSubclones(CNAmat[,2], results.com,hcc, n_subclones, samp, output_dir = output_dir)
+    
+    
+    save(results.com, file = file.path(output_dir, paste0(samp, "_CNAmtxSubclones.RData")))
     
   }else{
     n_subclones <- 0
@@ -207,14 +210,15 @@ subclonesTumorCells <- function(tum_cells, CNAmat, samp, n.cores, beta_vega, res
 }
 
 
-analyzeSegm <- function(samp, nSub = 1){
+analyzeSegm <- function(samp, nSub = 1, output_dir = "./output"){
+  #TODO this one needs to be updated as well
   
   all_segm <- list()
   
   if(nSub > 0){
     for (i in 1:nSub){
-
-      segm <- read.csv(paste0("./output/",samp,"_subclone",i,"_CN.seg"), sep = "\t")
+      
+      segm <- read.csv(file.path(output_dir, paste0(samp, "_subclone", i, "_CN.seg")), sep = "\t")
       specSegm <- getPossibleSpecAltFromSeg(segm)
       if(is.null(specSegm)) specSegm <- data.frame()
       all_segm[[paste0(samp,"_subclone", i)]] <- specSegm
@@ -222,7 +226,8 @@ analyzeSegm <- function(samp, nSub = 1){
     }
   }else{
     #segm <- read.csv(paste0("./output/ ",samp," _  _CN.seg"), sep = "\t")
-    segm <- read.csv(paste0("./output/",samp,"_Clonal_CN.seg"), sep = "\t")
+    
+    segm <- read.csv(file.path(output_dir, paste0(samp, "_Clonal_CN.seg")), sep = "\t")
     all_segm <- getPossibleSpecAltFromSeg(segm)
   }
   
@@ -230,19 +235,21 @@ analyzeSegm <- function(samp, nSub = 1){
   
 }
 
+# This whole function is never called anywhere - can be depreciated. 
+# Outside the scope of my PR (Alex van Kaam, 07-03-2025)
 analyzeSegm2 <- function(samp, nSub = 1){
-  
+
   all_segm <- list()
-  
+
   for (i in 1:nSub){
-    
+
     segm <- read.csv(paste0("./output/ ",samp,"_subclone",i," vega_output"), sep = "\t")
     all_segm[[paste0(samp,"_subclone", i)]] <- getPossibleSpecAltFromSeg(segm)
-    
+
   }
-  
+
   return(all_segm)
-  
+
 }
 
 getPossibleSpecAltFromSeg <- function(segm, name){
@@ -300,7 +307,6 @@ getPossibleSpecAltFromSeg <- function(segm, name){
   
   
   return(segm_new)
-  
 } 
 
 
@@ -739,7 +745,7 @@ testSpecificSubclonesAlteration <- function(listAltSubclones, nSub = 2, samp){
   return(subclonesAlt2)
 }
 
-genesDE <- function(count_mtx, count_mtx_annot, clustersSub, samp, specAlt, par_cores = 20){
+genesDE <- function(count_mtx, count_mtx_annot, clustersSub, samp, specAlt, par_cores = 20, output_dir = "./output"){
 
   #save(count_mtx, count_mtx_annot, clustersSub, samp, specAlt, par_cores, file = paste0(samp,"genesDE.RData"))
   
@@ -811,7 +817,10 @@ genesDE <- function(count_mtx, count_mtx_annot, clustersSub, samp, specAlt, par_
       
       if(FOUND_SIGN_DE){
       
-      png(paste("./output/",samp,"-DE", "chr",chrr,"-",startpos,"-",endpos, "_subclones.png",sep=""), height=850, width=1250, res=150)
+      #TODO
+      # add output_dir var and update calls to include output_dir
+      
+      png(file.path(output_dir, paste0(samp, "-DE", "chr", chrr, "-", startpos, "-", endpos, "_subclones.png")), height=850, width=1250, res=150)
       
       p1 <- ggplot(fact_spec2, aes(fc, p_value, label = geneID)) + geom_point() + txtRepel +
         xlab("log2 Fold Change") + ylab("-log10 pvalue") + ggtitle(paste(samp,"- DE", "chr",chrr,":",startpos,":",endpos)) + theme_bw(base_size = 16) + 
@@ -827,7 +836,7 @@ genesDE <- function(count_mtx, count_mtx_annot, clustersSub, samp, specAlt, par_
   
 }
 
-pathwayAnalysis <- function(count_mtx, count_mtx_annot, clustersSub, samp, par_cores = 20, organism = "human"){
+pathwayAnalysis <- function(count_mtx, count_mtx_annot, clustersSub, samp, par_cores = 20, organism = "human", output_dir = "./output"){
 
   library(forcats)
   library(ggplot2)
@@ -871,8 +880,9 @@ pathwayAnalysis <- function(count_mtx, count_mtx_annot, clustersSub, samp, par_c
   topPathways <- topUp %>% 
     arrange(-NES)
   
+  #TODO update to include output_dir
   #save(fgseaRes,topPathways, file = paste(samp,"pathwayAnalysis_subclones",sub,".RDATA"))
-  png(paste("./output/",samp,"pathwayAnalysis_subclones",sub,".png",sep=""), width = 1600, height = 1080, units = "px", res=100)
+  png(file.path(output_dir, paste0(samp, "pathwayAnalysis_subclones", sub, ".png")), width = 1600, height = 1080, units = "px", res=100)
 
   colnames(fgseaRes)[3] <- "pvalue"
   
@@ -890,9 +900,6 @@ pathwayAnalysis <- function(count_mtx, count_mtx_annot, clustersSub, samp, par_c
   
 }
 
-
-
-    
 #' annoteBandOncoHeat Annotate with chromosome bands the data frame with difference copy number alterations between subclones
 #'
 #' @param mtx_annot Annotation matrix

--- a/R/vegaMC.R
+++ b/R/vegaMC.R
@@ -6,7 +6,11 @@ vegaMC_R <- function(mtx, output_file_name="output",
                      mart_database="ensembl",
                      ensembl_dataset="hsapiens_gene_ensembl"){
   
-  
+  #TODO - this line checks for empty output string and whether it ends in "/".
+  # most likely for handling how "run_vegaMC" handles the saving later on.
+  # changing the default here to require an input from pipelineCNA would
+  # already fix the problem if the default there is changed to be consistent
+  # across the package.
   if( output_file_name == "" || 
       substr(output_file_name, 
              nchar(output_file_name), nchar(output_file_name)) == "/" ){
@@ -92,11 +96,12 @@ vegaMC_R <- function(mtx, output_file_name="output",
   #segmentation[ind_overflow,2] <- segmentation[ind_overflow,2] + (2 * (maxINT + 1))
   #segmentation[ind_overflow,3] <- segmentation[ind_overflow,3] + (2 * (maxINT + 1))
   
+  #TODO - same thing as above here - changing the default output_file_name
+  # would allow the user to give a specific output dir to write to
   write.table(segmentation, output_file_name, sep="\t", row.names=FALSE,
               col.names=TRUE, quote=FALSE, eol="\n")
   
   return(segmentation)   
-  
 }
 
 
@@ -111,11 +116,9 @@ vegaMC_R <- function(mtx, output_file_name="output",
 #' @export
 #'
 #' @examples
-getBreaksVegaMC <- function(mtx, chr_vect, sample = "", beta_vega = 0.5){
+getBreaksVegaMC <- function(mtx, chr_vect, sample = "", beta_vega = 0.5, output_dir = "./output"){
   
-  #write.table(mtx, paste("./output/", sample, "_mtx_vega.txt", sep=""), sep="\t", row.names = FALSE, quote = F)
-  
-  res_vega <- vegaMC_R(mtx = mtx, output_file_name=paste("./output/", sample,"vega_output"), beta = beta_vega);
+  res_vega <- vegaMC_R(mtx = mtx, output_file_name = file.path(output_dir, paste0(sample, "vega_output")), beta = beta_vega);
   
   BR <- unlist(lapply(res_vega$Start, function(x) which(chr_vect == x)[1]))
   n <- nrow(mtx)


### PR DESCRIPTION
I've added the `output_dir` functionality and done some limited testing - all files do seem to end up in the correct folder as given to `pipelineCNA`, while also retaining the base functionality of writing to ./output in the case that no `output_dir` is given retaining the default behaviour for users that update to a new version of the package and don't make changes to their code. The changes mostly come down to moving from `paste0("./output/", variables)` to `file.path(output_dir, paste0(variables)`.

One thing I did notice - it seems the segmentation of subclones runs twice, with _slightly_ different results between runs - One of the subclones gets merged into another one, and all the .seg files get recreated in this step. I've attached a .txt file showing my console output of this happening. It's outside the scope of this PR to figure out exactly why that's happening, but might be an important avenue to pursue if you see the same effects.

There furthermore seem to be some functions that never get called anywhere - I've deleted one of those, others I've kept around because they seem to be required for testing that isn't included in this repo. Apologies if that causes trouble somewhere down the road.

Feel free to get in touch for clarification!

[SCEVAN_seg_bug.txt](https://github.com/user-attachments/files/19163925/SCEVAN_seg_bug.txt)

